### PR TITLE
Optional, Tuple, ArrayLike

### DIFF
--- a/MicroLIA/simulate.py
+++ b/MicroLIA/simulate.py
@@ -20,6 +20,9 @@ import numpy as np
 import os
 import sys
 
+from numpy.typing import ArrayLike
+from typing import Optional, Tuple
+
 def microlensing(
     timestamps: ArrayLike,
     baseline: float,

--- a/MicroLIA/simulate.py
+++ b/MicroLIA/simulate.py
@@ -26,10 +26,10 @@ from typing import Optional, Tuple
 def microlensing(
     timestamps: ArrayLike,
     baseline: float,
-    t0_dist: Tuple[float, float] | None = None,
-    u0_dist: Tuple[float, float] | None = None,
-    tE_dist: Tuple[float, float] | None = None,
-) -> Tuple[np.ndarray, float, float, float, float]:
+    t0_dist: Optional[Tuple[float, float]] = None,
+    u0_dist: Optional[Tuple[float, float]] = None,
+    tE_dist: Optional[Tuple[float, float]] = None,
+) -> Optional[Tuple[np.ndarray, float, float, float, float]]:
     """
     Simulate a single-lens, point-source microlensing event with blending.
 


### PR DESCRIPTION
I added imports from numpy.typing for ArrayLike and typing for Optional, Tuple in order to make sure Tuple and ArrayLike were defined. This is because I encountered an error running MicroLIA on my local machine in the simulate.py script.